### PR TITLE
Stop requiring root access to develop the site

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,8 @@ development machine so that it pretends to be
 
 2. Create a new consumer, with these details:
 
-        Consumer Name: Boston Python Study Groups
-        Application Website: http://dev-studygroup.bostonpython.com
-        De-authorization URL: http://dev-studygroup.bostonpython.com/deauth
-        Redirect URI: http://dev-studygroup.bostonpython.com/
+        Consumer Name: Boston Python Study Groups (Dev)
+        Redirect URI: http://localhost:8080/
 
 3. Create a settings_local.py alongside settings.py, with details from the
     OAuth consumer you just created:
@@ -32,23 +30,17 @@ development machine so that it pretends to be
 
 4. Create the database tables:
 
-        $ sudo python manage.py create_tables
+        $ python manage.py create_tables
 
-5. You have to be able to visit your dev machine using the domain name
-    "dev-studygroup.bostonpython.com".  The simplest way to do this is to edit
-    /etc/hosts.  Add this line to the file:
+5. Start the server:
 
-        127.0.0.1   dev-studygroup.bostonpython.com
+        $ python run_server.py -p 8080
 
-6. Start the server:
-
-        $ sudo python run_server.py
-
-7. Visit the page in your browser using the URL http://dev-studygroup.bostonpython.com.
+6. Visit the page in your browser using the URL http://localhost:8080.
     You should see the Study Group page, and your server window should show
     URLs being served.
 
-8. If you click the Sign In Now button, it should take you to meetup.com and
+7. If you click the Sign In Now button, it should take you to meetup.com and
     ask you to authorize Boston Python Study Groups.
 
 

--- a/run_server.py
+++ b/run_server.py
@@ -1,6 +1,12 @@
+import argparse
+
 from studygroup.application import create_app
 
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Runs a study group site.')
+    parser.add_argument('--port', '-p', action='store', default=80, type=int)
+    args = parser.parse_args()
+
     app = create_app(debug=True)
-    app.run(debug=True, port=80)
+    app.run(debug=True, port=args.port)


### PR DESCRIPTION
Add a port option to run_server.py and update README.md to have the
minimal required step to get the site running.
